### PR TITLE
feat(plugin): add persistence.nvim with tmux-resurrect support

### DIFF
--- a/lua/plugins/persistence.lua
+++ b/lua/plugins/persistence.lua
@@ -1,0 +1,23 @@
+return {
+	"folke/persistence.nvim",
+	init = function()
+		local nvim_sessions = vim.fn.stdpath "state" .. "/sessions/"
+		local tmux_sessions = vim.fn.expand "~/.local/share/tmux/resurrect/"
+
+		local tmux_sessions_exists = vim.fn.empty(
+			vim.fn.globpath(tmux_sessions, "*")
+		) == 0
+
+		local nvim_sessions_exists = vim.fn.empty(
+			vim.fn.globpath(nvim_sessions, "*")
+		) == 0
+
+		local is_inside_tmux = vim.env.TMUX ~= nil
+
+		if nvim_sessions_exists and tmux_sessions_exists and is_inside_tmux then
+			-- Restore neovim sessions
+			require("persistence").load()
+		end
+	end,
+	opts = {},
+}


### PR DESCRIPTION
**features:**
- only restore neovim sessions if there are existing tmux-resurrect sessions
- only restore neovim sessions when attached to a tmux session