### PR TITLE
feat(formatting): add formatter for golang and rust

### DIFF
--- a/lua/plugins/formatting.lua
+++ b/lua/plugins/formatting.lua
@@ -33,6 +33,8 @@ return {
 			end,
 			formatters_by_ft = {
 				lua = { "stylua" },
+				go = { "goimports", "gofmt" },
+				rust = { "rustfmt", lsp_format = "fallback" },
 				javascript = { "prettierd", "prettier", "eslint_d" },
 				typescript = { "prettierd", "prettier", "eslint_d" },
 				javascriptreact = { "prettierd", "prettier", "eslint_d" },

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -40,6 +40,9 @@ return {
 					"shfmt",
 					"stylua",
 					"prettier",
+					"gofumpt",
+					"goimports",
+					"rustfmt",
 				},
 			}
 		end,


### PR DESCRIPTION
**Added formatters:**
- rustfmt
- goimports
- gofmt

> [!Important]
> **Install the following formatters by running `:MasonToolsInstall` in command mode.**