### PR TITLE
feature(telescope): add custom live grep

### DIFF
--- a/lua/custom/telescope/live_grep.lua
+++ b/lua/custom/telescope/live_grep.lua
@@ -1,0 +1,83 @@
+return function(opts)
+	local conf = require("telescope.config").values
+	local finders = require "telescope.finders"
+	local make_entry = require "telescope.make_entry"
+	local pickers = require "telescope.pickers"
+
+	opts = opts or {}
+	opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
+	opts.shortcuts = opts.shortcuts
+		or {
+			["c"] = "*.c",
+			["go"] = "*.go",
+			["java"] = "*.java",
+			["js"] = "*.js",
+			["json"] = "*.json",
+			["lua"] = "*.lua",
+			["rs"] = "*.rs",
+			["sc"] = "*.sc",
+			["scala"] = "*.scala",
+			["tf"] = "*.tf",
+			["ts"] = "*.ts",
+			["vim"] = "*.vim",
+			["yaml"] = "*.yaml",
+			["yml"] = "*.yml",
+		}
+
+	opts.pattern = opts.pattern or "%s"
+
+	local custom_grep = finders.new_async_job {
+		command_generator = function(prompt)
+			if not prompt or prompt == "" then return nil end
+
+			local double_space = "  "
+			local prompt_split = vim.split(prompt, double_space)
+
+			local args = { "rg" }
+			if prompt_split[1] then
+				table.insert(args, "-e")
+				table.insert(args, prompt_split[1])
+			end
+
+			if prompt_split[2] then
+				table.insert(args, "-g")
+
+				local pattern
+				if opts.shortcuts[prompt_split[2]] then
+					pattern = opts.shortcuts[prompt_split[2]]
+				else
+					pattern = prompt_split[2]
+				end
+
+				table.insert(args, string.format(opts.pattern, pattern))
+			end
+
+			return vim.iter({
+				args,
+				{
+					"--color=never",
+					"--no-heading",
+					"--with-filename",
+					"--line-number",
+					"--column",
+					"--smart-case",
+				},
+			})
+				:flatten()
+				:totable()
+		end,
+		entry_maker = make_entry.gen_from_vimgrep(opts),
+		cwd = opts.cwd,
+	}
+
+	pickers
+		.new(opts, {
+			debounce = 100,
+			prompt_title = "Custom Live Grep",
+			initial_mode = "insert",
+			finder = custom_grep,
+			previewer = conf.grep_previewer(opts),
+			sorter = require("telescope.sorters").empty(),
+		})
+		:find()
+end

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -118,7 +118,7 @@ return {
 			vim.keymap.set(
 				"n",
 				"<leader>sg",
-				builtin.live_grep,
+				require "custom.telescope.live_grep",
 				{ desc = "[S]earch by [G]rep" }
 			)
 			vim.keymap.set(


### PR DESCRIPTION
This PR extends the functionality of `telescope.builtin.live_grep` for searching patterns. 

And what `custom.telescope.live_grep` does is it allows you to not just only search for text patterns but also filter/restrict the results by file type/extension.

**Example Usage**:

the structure of your search string must be like this where `double space` is the separator between `text pattern` and `file type filter`:

*search pattern example:*
- `text pattern` + `double space` + `file type filter`

![Screenshot from 2025-05-22 at 21:46:41](https://github.com/user-attachments/assets/39c19f20-cf1b-46b0-87d5-e0db58d902e7)
