### PR TITLE
chore: set live_grep layout strategy to vertical

### DIFF
--- a/lua/custom/telescope/live_grep.lua
+++ b/lua/custom/telescope/live_grep.lua
@@ -78,6 +78,13 @@ return function(opts)
 			finder = custom_grep,
 			previewer = conf.grep_previewer(opts),
 			sorter = require("telescope.sorters").empty(),
+			layout_strategy = "vertical",
+			layout_config = {
+				preview_cutoff = 20,
+				prompt_position = "bottom",
+				height = 0.95,
+				width = 0.95,
+			},
 		})
 		:find()
 end


### PR DESCRIPTION
<img width="1366" height="768" alt="Screenshot from 2025-10-15 at 23:44:07" src="https://github.com/user-attachments/assets/f8e462c0-968c-4471-9395-6f689ae87319" />
