### PR TITLE
feature(plugin): add avante ai companion

### DIFF
--- a/lua/plugins/avante.lua
+++ b/lua/plugins/avante.lua
@@ -1,0 +1,73 @@
+return {
+	"yetone/avante.nvim",
+	-- if you want to build from source then do `make BUILD_FROM_SOURCE=true`
+	-- ⚠️ must add this setting! ! !
+	enabled = true,
+	build = "make",
+	event = "VeryLazy",
+	version = false, -- Never set this value to "*"! Never!
+	---@module 'avante'
+	opts = {
+		-- add any opts here
+		-- for example
+		provider = "openai",
+		providers = {
+			claude = {
+				endpoint = "https://api.anthropic.com",
+				model = "claude-sonnet-4-20250514",
+				timeout = 30000, -- Timeout in milliseconds
+				extra_request_body = {
+					temperature = 0.75,
+					max_tokens = 20480,
+				},
+			},
+			moonshot = {
+				endpoint = "https://api.moonshot.ai/v1",
+				model = "kimi-k2-0711-preview",
+				timeout = 30000, -- Timeout in milliseconds
+				extra_request_body = {
+					temperature = 0.75,
+					max_tokens = 32768,
+				},
+			},
+		},
+	},
+	dependencies = {
+		"nvim-lua/plenary.nvim",
+		"MunifTanjim/nui.nvim",
+		--- The below dependencies are optional,
+		"echasnovski/mini.pick", -- for file_selector provider mini.pick
+		"nvim-telescope/telescope.nvim", -- for file_selector provider telescope
+		"hrsh7th/nvim-cmp", -- autocompletion for avante commands and mentions
+		"ibhagwan/fzf-lua", -- for file_selector provider fzf
+		-- 'stevearc/dressing.nvim', -- for input provider dressing
+		"folke/snacks.nvim", -- for input provider snacks
+		"nvim-tree/nvim-web-devicons", -- or echasnovski/mini.icons
+		"zbirenbaum/copilot.lua", -- for providers='copilot'
+		{
+			-- support for image pasting
+			"HakonHarnes/img-clip.nvim",
+			event = "VeryLazy",
+			opts = {
+				-- recommended settings
+				default = {
+					embed_image_as_base64 = false,
+					prompt_for_file_name = false,
+					drag_and_drop = {
+						insert_mode = true,
+					},
+					-- required for Windows users
+					use_absolute_path = true,
+				},
+			},
+		},
+		{
+			-- Make sure to set this up properly if you have lazy=true
+			"MeanderingProgrammer/render-markdown.nvim",
+			opts = {
+				file_types = { "markdown", "Avante" },
+			},
+			ft = { "markdown", "Avante" },
+		},
+	},
+}


### PR DESCRIPTION
> [!Important]
> Make sure to export your AI provider’s API key in your environment variables so **Avante** can authenticate with the provider.
>
> Add this to your `.zshenv` if you’re using **Zsh** as your default shell:
```sh
export AVANTE_OPENAI_API_KEY="your-api-key"
```