### PR TITLE
fix(treesitter): fix highlighting

### DIFF
--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -2,9 +2,10 @@ return {
 	{ -- Fuzzy Finder (files, lsp, etc)
 		"nvim-telescope/telescope.nvim",
 		event = "VimEnter",
-		branch = "0.1.x",
+		version = "*",
 		dependencies = {
 			"nvim-lua/plenary.nvim",
+			"nvim-treesitter/nvim-treesitter",
 			{ -- If encountering errors, see telescope-fzf-native README for installation instructions
 				"nvim-telescope/telescope-fzf-native.nvim",
 

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -1,8 +1,11 @@
 return {
-	{ -- Highlight, edit, and navigate code
+	{
 		"nvim-treesitter/nvim-treesitter",
 		build = ":TSUpdate",
-		main = "nvim-treesitter.configs", -- Sets main module to use for opts
+		main = "nvim-treesitter.config", -- Sets main module to use for opts
+		event = { "BufReadPost", "BufNewFile" },
+		lazy = false,
+		branch = "main",
 		-- [[ Configure Treesitter ]] See `:help nvim-treesitter`
 		opts = {
 			ensure_installed = {
@@ -31,11 +34,5 @@ return {
 			},
 			indent = { enable = true, disable = { "ruby" } },
 		},
-		-- There are additional nvim-treesitter modules that you can use to interact
-		-- with nvim-treesitter. You should go explore a few and see what interests you:
-		--
-		--    - Incremental selection: Included, see `:help nvim-treesitter-incremental-selection-mod`
-		--    - Show your current context: https://github.com/nvim-treesitter/nvim-treesitter-context
-		--    - Treesitter + textobjects: https://github.com/nvim-treesitter/nvim-treesitter-textobjects
 	},
 }


### PR DESCRIPTION
**Step 1** - restore `lazy-lock.json`
```sh
git restore lazy-lock.json
```
**Step 2** - Open neovim
```sh
nvim
```
**Step 3** - uninstall telescope and treesitter
```
:Lazy clean nvim-treesitter telescope.nvim
```
**Step 4** - reinstall telescope and treesitter
```
:Lazy install nvim-treesitter telescope.nvim
```
**Step 5** - restore plugin versions from lock file
```
:Lazy restore
```