### PR TITLE
refactor(formatter): simplify conform.nvim configuration and adjust LSP format strategy

### DIFF
--- a/lua/plugins/formatting.lua
+++ b/lua/plugins/formatting.lua
@@ -1,57 +1,52 @@
-return {
-	{ -- Autoformat
-		"stevearc/conform.nvim",
-		event = { "BufWritePre" },
-		cmd = { "ConformInfo" },
-		keys = {
-			{
-				"<leader>f",
-				function()
-					require("conform").format {
-						async = true,
-						lsp_format = "fallback",
-					}
-				end,
-				mode = "",
-				desc = "[F]ormat buffer",
-			},
-		},
-		opts = {
-			notify_on_error = false,
-			format_on_save = function(bufnr)
-				local disable_filetypes = { c = true, cpp = true }
-				local lsp_format_opt
-				if disable_filetypes[vim.bo[bufnr].filetype] then
-					lsp_format_opt = "never"
-				else
-					lsp_format_opt = "fallback"
-				end
-				return {
-					timeout_ms = 500,
-					lsp_format = lsp_format_opt,
+return { -- Autoformat
+	"stevearc/conform.nvim",
+	event = { "BufWritePre" },
+	cmd = { "ConformInfo" },
+	keys = {
+
+		{
+			"<leader>f",
+			function()
+				require("conform").format {
+					async = true,
+					lsp_format = "never",
 				}
 			end,
-			formatters_by_ft = {
-				lua = { "stylua" },
-				go = { "goimports", "gofmt" },
-				rust = { "rustfmt", lsp_format = "fallback" },
-				javascript = { "prettierd", "prettier", "eslint_d" },
-				typescript = { "prettierd", "prettier", "eslint_d" },
-				javascriptreact = { "prettierd", "prettier", "eslint_d" },
-				typescriptreact = { "prettierd", "prettier", "eslint_d" },
-				svelte = { "prettierd", "prettier" },
-				css = { "prettierd", "prettier" },
-				html = { "prettierd", "prettier" },
-				json = { "prettierd", "prettier" },
-				yaml = { "prettierd", "prettier" },
-				terraform = { "terraform_fmt" },
-				hcl = { "terragrunt_hclfmt", "packer_fmt" },
-				markdown = { "prettierd", "prettier" },
-				graphql = { "prettierd", "prettier" },
-				java = { "google_java_format" },
-				nix = { "alejandra" },
-			},
-			stop_after_first = true, -- Ensures only the first formatter is used
+			desc = "[F]ormat buffer",
 		},
+	},
+	opts = {
+		notify_on_error = true,
+		format_on_save = { timeout_ms = 500, lsp_format = "never" },
+		formatters = {
+			["prettier"] = {
+				prepend_args = {
+					"--ignore-unknown",
+					"--config-precedence",
+					"prefer-file",
+				},
+			},
+		},
+		formatters_by_ft = {
+			lua = { "stylua" },
+			go = { "goimports", "gofmt" },
+			rust = { "rustfmt", lsp_format = "fallback" },
+			javascript = { "prettierd", "prettier", "eslint_d" },
+			typescript = { "prettierd", "prettier", "eslint_d" },
+			javascriptreact = { "prettierd", "prettier", "eslint_d" },
+			typescriptreact = { "prettierd", "prettier", "eslint_d" },
+			svelte = { "prettierd", "prettier" },
+			css = { "prettierd", "prettier" },
+			html = { "prettierd", "prettier" },
+			json = { "prettierd", "prettier" },
+			yaml = { "prettierd", "prettier" },
+			terraform = { "terraform_fmt" },
+			hcl = { "terragrunt_hclfmt", "packer_fmt" },
+			markdown = { "prettierd", "prettier" },
+			graphql = { "prettierd", "prettier" },
+			java = { "google_java_format" },
+			nix = { "alejandra" },
+		},
+		stop_after_first = true, -- Ensures only the first formatter is used
 	},
 }


### PR DESCRIPTION
- Flatten nested table structure for improved readability
- Change lsp_format from 'fallback' to 'never' to rely exclusively on conform
- Simplify format_on_save to inline configuration
- Add explicit prettier configuration with --ignore-unknown flag
- Add --config-precedence prefer-file flag for prettier
- Change notify_on_error from false to true for better error visibility